### PR TITLE
players move slower as they grow bigger

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -4,57 +4,44 @@ function Player(name, x, y, mass, keyTracker) {
   this.y    = y;
   this.mass = mass || 5;
   this.keyTracker = keyTracker;
+  this.speed = 5;
 }
 
 Player.prototype = {
-  speed: function() {
-    if (this.mass > 50){
-      return 1;
-    } else if (this.mass > 30) {
-      return 2
-    } else if (this.mass > 20){
-      return 3
-    } else if (this.mass > 10) {
-      return 4
-    } else {
-      return 5
-    };
-  },
-
   move: function() {
     if (this.name === 'Player 1') {
       if(this.keyTracker.isPressed(this.keyTracker.keys.P1LEFT) &&
          this.keyTracker.canMoveLeft(this)) {
-        this.x -= this.speed();
+        this.x -= this.speed;
       }
       if (this.keyTracker.isPressed(this.keyTracker.keys.P1RIGHT) &&
           this.keyTracker.canMoveRight(this)) {
-        this.x += this.speed();
+        this.x += this.speed;
       }
       if (this.keyTracker.isPressed(this.keyTracker.keys.P1UP) &&
           this.keyTracker.canMoveUp(this)) {
-        this.y -= this.speed();
+        this.y -= this.speed;
       }
       if (this.keyTracker.isPressed(this.keyTracker.keys.P1DOWN) &&
           this.keyTracker.canMoveDown(this)) {
-        this.y += this.speed();
+        this.y += this.speed;
       }
     } else if (this.name === 'Player 2') {
       if(this.keyTracker.isPressed(this.keyTracker.keys.P2LEFT) &&
          this.keyTracker.canMoveLeft(this)) {
-        this.x -= this.speed();
+        this.x -= this.speed;
       }
       if (this.keyTracker.isPressed(this.keyTracker.keys.P2RIGHT) &&
           this.keyTracker.canMoveRight(this)) {
-        this.x += this.speed();
+        this.x += this.speed;
       }
       if (this.keyTracker.isPressed(this.keyTracker.keys.P2UP) &&
           this.keyTracker.canMoveUp(this)) {
-        this.y -= this.speed();
+        this.y -= this.speed;
       }
       if (this.keyTracker.isPressed(this.keyTracker.keys.P2DOWN) &&
           this.keyTracker.canMoveDown(this)) {
-        this.y += this.speed();
+        this.y += this.speed;
       }
     }
     return this;
@@ -68,6 +55,7 @@ Player.prototype = {
       if(distance < this.mass) {
         food.splice(i, 1);
         this.mass += 1;
+        if (this.speed > 0.8){ this.speed -= 0.03; }
       }
     }
   }

--- a/lib/player.js
+++ b/lib/player.js
@@ -4,96 +4,72 @@ function Player(name, x, y, mass, keyTracker) {
   this.y    = y;
   this.mass = mass || 5;
   this.keyTracker = keyTracker;
-
-  this.movePlayer = function(xOffset, yOffset) {
-    this.x += xOffset;
-    this.y += yOffset;
-  };
-  this.moveLeft = this.movePlayer.bind(this, -1, 0);
-  this.moveRight = this.movePlayer.bind(this, 1, 0);
-  this.moveUp = this.movePlayer.bind(this, 0, -1);
-  this.moveDown = this.movePlayer.bind(this, 0, 1);
 }
 
 Player.prototype = {
+  speed: function() {
+    if (this.mass > 50){
+      return 1;
+    } else if (this.mass > 30) {
+      return 2
+    } else if (this.mass > 20){
+      return 3
+    } else if (this.mass > 10) {
+      return 4
+    } else {
+      return 5
+    };
+  },
+
   move: function() {
-    this.movePlayer1();
-    this.movePlayer2();
+    if (this.name === 'Player 1') {
+      if(this.keyTracker.isPressed(this.keyTracker.keys.P1LEFT) &&
+         this.keyTracker.canMoveLeft(this)) {
+        this.x -= this.speed();
+      }
+      if (this.keyTracker.isPressed(this.keyTracker.keys.P1RIGHT) &&
+          this.keyTracker.canMoveRight(this)) {
+        this.x += this.speed();
+      }
+      if (this.keyTracker.isPressed(this.keyTracker.keys.P1UP) &&
+          this.keyTracker.canMoveUp(this)) {
+        this.y -= this.speed();
+      }
+      if (this.keyTracker.isPressed(this.keyTracker.keys.P1DOWN) &&
+          this.keyTracker.canMoveDown(this)) {
+        this.y += this.speed();
+      }
+    } else if (this.name === 'Player 2') {
+      if(this.keyTracker.isPressed(this.keyTracker.keys.P2LEFT) &&
+         this.keyTracker.canMoveLeft(this)) {
+        this.x -= this.speed();
+      }
+      if (this.keyTracker.isPressed(this.keyTracker.keys.P2RIGHT) &&
+          this.keyTracker.canMoveRight(this)) {
+        this.x += this.speed();
+      }
+      if (this.keyTracker.isPressed(this.keyTracker.keys.P2UP) &&
+          this.keyTracker.canMoveUp(this)) {
+        this.y -= this.speed();
+      }
+      if (this.keyTracker.isPressed(this.keyTracker.keys.P2DOWN) &&
+          this.keyTracker.canMoveDown(this)) {
+        this.y += this.speed();
+      }
+    }
     return this;
   },
 
   eatFood: function(food) {
     for(var i = 0; i < food.length; i++) {
-      var xDiff = this.x - food[i].x;
-      var yDiff = this.y - food[i].y;
+      var xDiff = this.x - food[i].x
+      var yDiff = this.y - food[i].y
       var distance = Math.sqrt( xDiff*xDiff + yDiff*yDiff );
       if(distance < this.mass) {
         food.splice(i, 1);
         this.mass += 1;
       }
     }
-  },
-
-  movePlayer1: function() {
-    if (this.isPlayer1()) {
-      if (this.attemptsValidMoveLeft('P1LEFT')) {
-        this.moveLeft();
-      }
-      if (this.attemptsValidMoveRight('P1RIGHT')) {
-        this.moveRight();
-      }
-      if (this.attemptsValidMoveUp('P1UP')) {
-        this.moveUp();
-      }
-      if (this.attemptsValidMoveDown('P1DOWN')) {
-        this.moveDown();
-      }
-    }
-  },
-
-  movePlayer2: function() {
-    if (this.isPlayer2()) {
-      if (this.attemptsValidMoveLeft('P2LEFT')) {
-        this.moveLeft();
-      }
-      if (this.attemptsValidMoveRight('P2RIGHT')) {
-        this.moveRight();
-      }
-      if (this.attemptsValidMoveUp('P2UP')) {
-        this.moveUp();
-      }
-      if (this.attemptsValidMoveDown('P2DOWN')) {
-        this.moveDown();
-      }
-    }
-  },
-
-  isPlayer1: function() {
-    return this.name === 'Player 1';
-  },
-
-  isPlayer2: function() {
-    return this.name === 'Player 2';
-  },
-
-  attemptsValidMoveLeft: function(key) {
-    return (this.keyTracker.isPressed(this.keyTracker.keys[key]) &&
-            this.keyTracker.canMoveLeft(this));
-  },
-
-  attemptsValidMoveRight: function(key) {
-    return (this.keyTracker.isPressed(this.keyTracker.keys[key]) &&
-            this.keyTracker.canMoveRight(this));
-  },
-
-  attemptsValidMoveUp: function(key) {
-    return (this.keyTracker.isPressed(this.keyTracker.keys[key]) &&
-            this.keyTracker.canMoveUp(this));
-  },
-
-  attemptsValidMoveDown: function(key) {
-    return (this.keyTracker.isPressed(this.keyTracker.keys[key]) &&
-        this.keyTracker.canMoveDown(this));
   }
 };
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -5,52 +5,27 @@ function Player(name, x, y, mass, keyTracker) {
   this.mass = mass || 5;
   this.keyTracker = keyTracker;
   this.speed = 5;
+  this.movePlayer = function(xOffset, yOffset) {
+    this.x += xOffset * this.speed;
+    this.y += yOffset * this.speed;
+  };
+  this.moveLeft = this.movePlayer.bind(this, -1, 0);
+  this.moveRight = this.movePlayer.bind(this, 1, 0);
+  this.moveUp = this.movePlayer.bind(this, 0, -1);
+  this.moveDown = this.movePlayer.bind(this, 0, 1);
 }
 
 Player.prototype = {
   move: function() {
-    if (this.name === 'Player 1') {
-      if(this.keyTracker.isPressed(this.keyTracker.keys.P1LEFT) &&
-         this.keyTracker.canMoveLeft(this)) {
-        this.x -= this.speed;
-      }
-      if (this.keyTracker.isPressed(this.keyTracker.keys.P1RIGHT) &&
-          this.keyTracker.canMoveRight(this)) {
-        this.x += this.speed;
-      }
-      if (this.keyTracker.isPressed(this.keyTracker.keys.P1UP) &&
-          this.keyTracker.canMoveUp(this)) {
-        this.y -= this.speed;
-      }
-      if (this.keyTracker.isPressed(this.keyTracker.keys.P1DOWN) &&
-          this.keyTracker.canMoveDown(this)) {
-        this.y += this.speed;
-      }
-    } else if (this.name === 'Player 2') {
-      if(this.keyTracker.isPressed(this.keyTracker.keys.P2LEFT) &&
-         this.keyTracker.canMoveLeft(this)) {
-        this.x -= this.speed;
-      }
-      if (this.keyTracker.isPressed(this.keyTracker.keys.P2RIGHT) &&
-          this.keyTracker.canMoveRight(this)) {
-        this.x += this.speed;
-      }
-      if (this.keyTracker.isPressed(this.keyTracker.keys.P2UP) &&
-          this.keyTracker.canMoveUp(this)) {
-        this.y -= this.speed;
-      }
-      if (this.keyTracker.isPressed(this.keyTracker.keys.P2DOWN) &&
-          this.keyTracker.canMoveDown(this)) {
-        this.y += this.speed;
-      }
-    }
+    this.movePlayer1();
+    this.movePlayer2();
     return this;
   },
 
   eatFood: function(food) {
     for(var i = 0; i < food.length; i++) {
-      var xDiff = this.x - food[i].x
-      var yDiff = this.y - food[i].y
+      var xDiff = this.x - food[i].x;
+      var yDiff = this.y - food[i].y;
       var distance = Math.sqrt( xDiff*xDiff + yDiff*yDiff );
       if(distance < this.mass) {
         food.splice(i, 1);
@@ -58,6 +33,68 @@ Player.prototype = {
         if (this.speed > 0.8){ this.speed -= 0.03; }
       }
     }
+  },
+
+  movePlayer1: function() {
+    if (this.isPlayer1()) {
+      if (this.attemptsValidMoveLeft('P1LEFT')) {
+        this.moveLeft();
+      }
+      if (this.attemptsValidMoveRight('P1RIGHT')) {
+        this.moveRight();
+      }
+      if (this.attemptsValidMoveUp('P1UP')) {
+        this.moveUp();
+      }
+      if (this.attemptsValidMoveDown('P1DOWN')) {
+        this.moveDown();
+      }
+    }
+  },
+
+  movePlayer2: function() {
+    if (this.isPlayer2()) {
+      if (this.attemptsValidMoveLeft('P2LEFT')) {
+        this.moveLeft();
+      }
+      if (this.attemptsValidMoveRight('P2RIGHT')) {
+        this.moveRight();
+      }
+      if (this.attemptsValidMoveUp('P2UP')) {
+        this.moveUp();
+      }
+      if (this.attemptsValidMoveDown('P2DOWN')) {
+        this.moveDown();
+      }
+    }
+  },
+
+  isPlayer1: function() {
+    return this.name === 'Player 1';
+  },
+
+  isPlayer2: function() {
+    return this.name === 'Player 2';
+  },
+
+  attemptsValidMoveLeft: function(key) {
+    return (this.keyTracker.isPressed(this.keyTracker.keys[key]) &&
+            this.keyTracker.canMoveLeft(this));
+  },
+
+  attemptsValidMoveRight: function(key) {
+    return (this.keyTracker.isPressed(this.keyTracker.keys[key]) &&
+            this.keyTracker.canMoveRight(this));
+  },
+
+  attemptsValidMoveUp: function(key) {
+    return (this.keyTracker.isPressed(this.keyTracker.keys[key]) &&
+            this.keyTracker.canMoveUp(this));
+  },
+
+  attemptsValidMoveDown: function(key) {
+    return (this.keyTracker.isPressed(this.keyTracker.keys[key]) &&
+        this.keyTracker.canMoveDown(this));
   }
 };
 

--- a/lib/shape-drawer.js
+++ b/lib/shape-drawer.js
@@ -6,7 +6,7 @@ function ShapeDrawer(canvas, context) {
 ShapeDrawer.prototype = {
   drawFood: function(food) {
     this.context.beginPath();
-    this.context.arc(food.x, food.y, 3, 0, Math.PI * 2);
+    this.context.arc(food.x, food.y, 5, 0, Math.PI * 2);
     this.context.fill();
     return this;
   },

--- a/test/player-eats-food-test.js
+++ b/test/player-eats-food-test.js
@@ -15,7 +15,7 @@ describe('Player eats food', function(){
       var foodArray = [food1]
 
       assert.equal(foodArray.length, 1)
-      player1.eatFood(foodArray)
+      player1.eatFood(foodArray) // the eatFood function checks the area around a player and eats anything in range
       assert.equal(foodArray.length, 0)
     });
 
@@ -49,14 +49,13 @@ describe('Player eats food', function(){
       assert.equal(foodArray.length, 1)
       player1.eatFood(foodArray)
       assert.equal(foodArray.length, 1)
-
+      // player1 needs to move 3 times towards the food to have it be in range to eat
       keyTracker.keyPressed[83] = true;
-      for(var i = 0; i < 10; i++){
-        player1.move();
-      };
+      player1.move();
       assert.equal(foodArray.length, 1)
-
       player1.move()
+      player1.move()
+
       player1.eatFood(foodArray)
       assert.equal(foodArray.length, 0)
     });

--- a/test/player-eats-food-test.js
+++ b/test/player-eats-food-test.js
@@ -51,12 +51,12 @@ describe('Player eats food', function(){
       assert.equal(foodArray.length, 1)
       // player1 needs to move 3 times towards the food to have it be in range to eat
       keyTracker.keyPressed[83] = true;
-      player1.move();
-      assert.equal(foodArray.length, 1)
-      player1.move()
-      player1.move()
 
-      player1.eatFood(foodArray)
+      for(var i = 0; i < 10; i++){
+        player1.move();
+        player1.eatFood(foodArray)
+      };
+
       assert.equal(foodArray.length, 0)
     });
   });

--- a/test/player-movements-test.js
+++ b/test/player-movements-test.js
@@ -15,11 +15,13 @@ describe('Player movement', function(){
       assert.equal(player1.x, 10);
       assert.equal(player2.x, 20);
 
+      var player1StartXcoor = player1.x
+
       keyTracker.keyPressed[65] = true;
       player1.move();
       player2.move();
 
-      assert.equal(player1.x, 9);
+      assert.equal(player1.x, player1StartXcoor - player1.speed);
       assert.equal(player2.x, 20);
     });
 
@@ -29,6 +31,8 @@ describe('Player movement', function(){
       let player1 = new Player("Player 1", 10, 10, 5, keyTracker);
       let player2 = new Player("Player 2", 20, 20, 5, keyTracker);
 
+      var player1StartXcoor = player1.x
+
       assert.equal(player1.x, 10);
       assert.equal(player2.x, 20);
 
@@ -36,7 +40,7 @@ describe('Player movement', function(){
       player1.move();
       player2.move();
 
-      assert.equal(player1.x, 11);
+      assert.equal(player1.x, player1StartXcoor + player1.speed);
       assert.equal(player2.x, 20);
     });
 
@@ -46,6 +50,8 @@ describe('Player movement', function(){
       let player1 = new Player("Player 1", 10, 10, 5, keyTracker);
       let player2 = new Player("Player 2", 20, 20, 5, keyTracker);
 
+      var player1StartYcoor = player1.y
+
       assert.equal(player1.y, 10);
       assert.equal(player2.y, 20);
 
@@ -53,7 +59,7 @@ describe('Player movement', function(){
       player1.move();
       player2.move();
 
-      assert.equal(player1.y, 9);
+      assert.equal(player1.y, player1StartYcoor - player1.speed);
       assert.equal(player2.y, 20);
     });
 
@@ -66,11 +72,13 @@ describe('Player movement', function(){
       assert.equal(player1.y, 10);
       assert.equal(player2.y, 20);
 
+      var player1StartYcoor = player1.y
+
       keyTracker.keyPressed[83] = true;
       player1.move();
       player2.move();
 
-      assert.equal(player1.y, 11);
+      assert.equal(player1.y, player1StartYcoor + player1.speed);
       assert.equal(player2.y, 20);
     });
   });
@@ -85,12 +93,14 @@ describe('Player movement', function(){
       assert.equal(player1.x, 10);
       assert.equal(player2.x, 20);
 
+      var player1StartXcoor = player2.x
+
       keyTracker.keyPressed[76] = true;
       player1.move();
       player2.move();
 
       assert.equal(player1.x, 10);
-      assert.equal(player2.x, 19);
+      assert.equal(player2.x, player1StartXcoor - player2.speed);
     });
 
     it('moves to the right independently', function(){
@@ -102,12 +112,14 @@ describe('Player movement', function(){
       assert.equal(player1.x, 10);
       assert.equal(player2.x, 20);
 
+      var player1StartXcoor = player2.x
+
       keyTracker.keyPressed[222] = true;
       player1.move();
       player2.move();
 
       assert.equal(player1.x, 10);
-      assert.equal(player2.x, 21);
+      assert.equal(player2.x, player1StartXcoor + player2.speed);
     });
 
     it('moves up independently', function(){
@@ -119,12 +131,14 @@ describe('Player movement', function(){
       assert.equal(player1.y, 10);
       assert.equal(player2.y, 20);
 
+      var player2StartYcoor = player2.y
+
       keyTracker.keyPressed[80] = true;
       player1.move();
       player2.move();
 
       assert.equal(player1.y, 10);
-      assert.equal(player2.y, 19);
+      assert.equal(player2.y, player2StartYcoor - player2.speed);
     });
 
     it('moves down independently', function(){
@@ -136,12 +150,14 @@ describe('Player movement', function(){
       assert.equal(player1.y, 10);
       assert.equal(player2.y, 20);
 
+      var player2StartYcoor = player2.y
+
       keyTracker.keyPressed[186] = true;
       player1.move();
       player2.move();
 
       assert.equal(player1.y, 10);
-      assert.equal(player2.y, 21);
+      assert.equal(player2.y, player2StartYcoor + player2.speed);
     });
   });
 


### PR DESCRIPTION
1. I had to take out the use of bind in the refactor of player movements.  It was binding the speed as well so the player's speed could not be adjusted.  

2. I changed the size of the food to be 5. This was intended to allow the food not to be skipped over if the speed of the player is more that +5 but that doesn't seem to matter.  I changed the start speed of the player to 5 and I think it's much more playable with the larger food.

3. I added a speed attribute to the player which checks the size of the player's mass and decreases the speed as the mass increases every 10 px until 50.

4. The current speed and size are up for change as the team wishes to adjust but the functionality is in place.