### PR TITLE
Speed boosts double your speed for 1200 ms

### DIFF
--- a/lib/food-generator.js
+++ b/lib/food-generator.js
@@ -1,4 +1,5 @@
 var Food = require('./food');
+var SpeedBoost = require('./speed-boost');
 var ShapeDrawer = require('./shape-drawer');
 
 function FoodGenerator(canvas, context) {
@@ -8,7 +9,7 @@ function FoodGenerator(canvas, context) {
 }
 
 FoodGenerator.prototype = {
-  seed: function() {
+  seedFood: function() {
     var food = [];
     for(var i = 0; i < 50; i++) {
       var foodItem = new Food(this.randOnCanvas(this.canvas));
@@ -17,15 +18,27 @@ FoodGenerator.prototype = {
     return food;
   },
 
+  seedSpeedBoosts: function() {
+    var speedBoosts = [];
+    for(var i = 0; i < 4; i++) {
+      var boost = new SpeedBoost(this.randOnCanvas());
+      speedBoosts.push(boost);
+    }
+    return speedBoosts;
+  },
+
   randOnCanvas: function() {
     return { x: Math.floor(Math.random() * (this.canvas.width - 10) + 5),
              y: Math.floor(Math.random() * (this.canvas.height - 10) + 5) };
   },
 
-  replaceFood: function(food){
+  replaceFood: function(food, speedBoosts) {
     while(food.length < 50) {
       var foodItem = new Food(this.randOnCanvas(this.canvas));
       food.push(foodItem);
+    }
+    while(speedBoosts.length < 4) {
+      speedBoosts.push(new SpeedBoost(this.randOnCanvas()));
     }
   }
 };

--- a/lib/food.js
+++ b/lib/food.js
@@ -1,6 +1,7 @@
 function Food(coords) {
   this.x = coords.x;
   this.y = coords.y;
-};
+  this.color = 'black';
+}
 
 module.exports = Food;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,24 +10,31 @@ var keyTracker = new KeyTracker(canvas);
 var foodGen = new FoodGenerator(canvas, ctx);
 
 var players = [];
-players.push(new Player('Player 1',200,50,5,keyTracker));
-players.push(new Player('Player 2',250,50,5,keyTracker));
+players.push(new Player('Player 1',200,50,8,keyTracker));
+players.push(new Player('Player 2',250,50,8,keyTracker));
 
-var food = foodGen.seed();
+var food = foodGen.seedFood();
+var boosts = foodGen.seedSpeedBoosts();
 
 requestAnimationFrame(function gameLoop() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-  for(var j = 0; j < food.length; j++) {
-    shapeDrawer.drawFood(food[j]);
+  for(var i = 0; i < food.length; i++) {
+    shapeDrawer.drawFood(food[i]);
   }
 
-  for(var i = 0; i < players.length; i++) {
-    shapeDrawer.drawPlayer(players[i]).move();
-    players[i].eatFood.call(players[i], food);
+  for(var j = 0; j < players.length; j++) {
+    players[j].resetBoost();
+    shapeDrawer.drawPlayer(players[j]).move();
+    players[j].eatFood.call(players[j], food);
+    players[j].eatBoosts.call(players[j], boosts);
   }
 
-  foodGen.replaceFood(food);
+  for(var k = 0; k < boosts.length; k++) {
+    shapeDrawer.drawFood(boosts[k]);
+  }
+
+  foodGen.replaceFood(food, boosts);
 
   requestAnimationFrame(gameLoop);
 });

--- a/lib/player.js
+++ b/lib/player.js
@@ -5,10 +5,17 @@ function Player(name, x, y, mass, keyTracker) {
   this.mass = mass || 5;
   this.keyTracker = keyTracker;
   this.speed = 5;
+  this.speedBoostTime = null;
   this.movePlayer = function(xOffset, yOffset) {
-    this.x += xOffset * this.speed;
-    this.y += yOffset * this.speed;
+    if (this.speedBoostTime !== null) {
+      this.x += xOffset * (this.speed * 2);
+      this.y += yOffset * (this.speed * 2);
+    } else {
+      this.x += xOffset * this.speed;
+      this.y += yOffset * this.speed;
+    }
   };
+
   this.moveLeft = this.movePlayer.bind(this, -1, 0);
   this.moveRight = this.movePlayer.bind(this, 1, 0);
   this.moveUp = this.movePlayer.bind(this, 0, -1);
@@ -32,6 +39,24 @@ Player.prototype = {
         this.mass += 1;
         if (this.speed > 0.8){ this.speed -= 0.03; }
       }
+    }
+  },
+
+  eatBoosts: function(boosts) {
+    for(var i = 0; i < boosts.length; i++) {
+      var xDiff = this.x - boosts[i].x;
+      var yDiff = this.y - boosts[i].y;
+      var distance = Math.sqrt( xDiff*xDiff + yDiff*yDiff );
+      if(distance < this.mass) {
+        boosts.splice(i, 1);
+        this.speedBoostTime = Date.now();
+      }
+    }
+  },
+
+  resetBoost: function() {
+    if(this.speedBoostTime < (Date.now() - 1200)) {
+      this.speedBoostTime = null;
     }
   },
 

--- a/lib/shape-drawer.js
+++ b/lib/shape-drawer.js
@@ -5,8 +5,10 @@ function ShapeDrawer(canvas, context) {
 
 ShapeDrawer.prototype = {
   drawFood: function(food) {
+    console.log(food);
     this.context.beginPath();
     this.context.arc(food.x, food.y, 5, 0, Math.PI * 2);
+    this.context.fillStyle = food.color;
     this.context.fill();
     return this;
   },
@@ -14,6 +16,7 @@ ShapeDrawer.prototype = {
   drawPlayer: function(player) {
     this.context.beginPath();
     this.context.arc(player.x, player.y, player.mass, 0, Math.PI * 2);
+    this.context.fillStyle = 'royalblue';
     this.context.fill();
     return player;
   }

--- a/lib/speed-boost.js
+++ b/lib/speed-boost.js
@@ -1,0 +1,7 @@
+function SpeedBoost(coords) {
+  this.x = coords.x;
+  this.y = coords.y;
+  this.color = '#42c32e';
+}
+
+module.exports = SpeedBoost;


### PR DESCRIPTION
@Jpease1020 @jwperry So, uh, I got a bit of a second wind tonight. What I thought would be a quick peek into speed boosts turned into getting annoyed that my setTimeout function wasn't resetting a players' speed and getting determined to find another way around it. Here's the process I came up with:

- adds speed boost seed and replace functionality to food generator
- adds boostSpeedTime property to player object, which defaults to null
- when a player hits a speed boost, the current time is saved into the boostSpeedTime (Date.now())
- if a player's boostSpeedTime is anything other than null when they move, their speed is doubled
- as part of the players iteration in the game loop, a player's boostSpeedTime is reset to null if it's less than 1200 milliseconds ago (Date.now() - 1200).